### PR TITLE
fix: encode X-Force WHOIS path values

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2021-2025 Splunk Inc.
+   Copyright (c) 2021-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: IBM X-Force Exchange
-Copyright (c) 2021-2025 Splunk Inc.
+Copyright (c) 2021-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2021-2025 Splunk Inc.
+# Copyright (c) 2021-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,4 @@
 **Unreleased**
 
-* - Updated connector development tooling.
+* Updated connector development tooling.
 * Encoded WHOIS query values as a single URL path segment before sending authenticated requests.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * - Updated connector development tooling.
+* Encoded WHOIS query values as a single URL path segment before sending authenticated requests.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Updated connector development tooling.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/ip_reputation_test.py
+++ b/tests/ip_reputation_test.py
@@ -1,6 +1,6 @@
 # File: ip_reputation_test.py
 #
-# Copyright (c) 2021-2025 Splunk Inc.
+# Copyright (c) 2021-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_file_rep.py
+++ b/tests/test_file_rep.py
@@ -1,6 +1,6 @@
 # File: test_file_rep.py
 #
-# Copyright (c) 2021-2025 Splunk Inc.
+# Copyright (c) 2021-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_url_reputation.py
+++ b/tests/test_url_reputation.py
@@ -1,6 +1,6 @@
 # File: test_url_reputation.py
 #
-# Copyright (c) 2021-2025 Splunk Inc.
+# Copyright (c) 2021-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_whois.py
+++ b/tests/test_whois.py
@@ -1,6 +1,6 @@
 # File: test_whois.py
 #
-# Copyright (c) 2021-2025 Splunk Inc.
+# Copyright (c) 2021-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xforce.json
+++ b/xforce.json
@@ -5,7 +5,7 @@
     "publisher": "Splunk",
     "package_name": "phantom_ibmxforceexchange",
     "type": "investigative",
-    "license": "Copyright (c) 2021-2025 Splunk Inc.",
+    "license": "Copyright (c) 2021-2026 Splunk Inc.",
     "copyright": "Copyright (c) 2021-2023 Splunk Inc.",
     "main_module": "xforce_connector.py",
     "app_version": "1.2.1",

--- a/xforce.py
+++ b/xforce.py
@@ -14,6 +14,7 @@
 # and limitations under the License.
 
 import base64
+from urllib.parse import quote
 
 import requests
 
@@ -149,7 +150,7 @@ class xforce:
         return json_response
 
     def get_whois(self, query_data):
-        response = self._send_request("/whois/" + query_data, "get")
+        response = self._send_request("/whois/" + quote(query_data, safe=""), "get")
         json_response = {"xforce_whois": response}
 
         return json_response

--- a/xforce.py
+++ b/xforce.py
@@ -1,6 +1,6 @@
 # File: xforce.py
 #
-# Copyright (c) 2021-2025 Splunk Inc.
+# Copyright (c) 2021-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xforce_connector.py
+++ b/xforce_connector.py
@@ -1,6 +1,6 @@
 # File: xforce_connector.py
 #
-# Copyright (c) 2021-2025 Splunk Inc.
+# Copyright (c) 2021-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- encode caller-supplied WHOIS queries as a single URL path segment
- prevent traversal, query, and fragment injection from redirecting authenticated requests
- refresh the connector tooling baseline to dev-cicd-tools v2.2.4

## Tracking

- PAPP-38205
- PSAAS-31012
- Parent epic: ESPM-5228

## Validation

- local pre-commit: passed
- hosted pre-commit and compile: pending

## AI assistance

- [x] This pull request was created entirely with AI assistance.

Written by Codex.